### PR TITLE
Add =~ (contains) operator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Development
 *.sw[onp]
+
+# IntelliJ artifacts
+.idea/
+*.iml

--- a/parameters.go
+++ b/parameters.go
@@ -10,6 +10,7 @@ const (
 	GreaterThanOrEqualsOperation = ParameterOperation(">=")
 	LessThanOperation            = ParameterOperation("<")
 	LessThanOrEqualsOperation    = ParameterOperation("<=")
+	ContainsOperation            = ParameterOperation("=~")
 )
 
 // A parameter you want to include when generating signed authentication tokens


### PR DESCRIPTION
This is an operator that is currently supported by Reflect.js but not `reflect-go`.